### PR TITLE
Minor site adjustments to fit branding/vibe

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
                 target="_blank" 
                 rel="noopener noreferrer"
               >
-                <button className="h-fit flex items-center justify-center px-4 py-2 rounded-sm bg-black gap-2 text-sm text-white border border-pillSecondary">
+                <button className="h-fit flex items-center justify-center px-4 py-2 rounded-md bg-[#1b2128] hover:bg-[#1d232b] gap-1 text-sm font-medium text-white border border-pillSecondary transition-colors duration-200">
                   <Image
                     src="/github.svg"
                     alt="GitHub"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,17 @@ import AnimatedButton from "./components/AnimatedButton";
 import Image from "next/image";
 import posthog from "posthog-js";
 
+const Tooltip = ({ children, text }: { children: React.ReactNode; text: string }) => {
+  return (
+    <div className="relative group">
+      {children}
+      <span className="absolute hidden group-hover:block w-auto px-3 py-2 min-w-max left-1/2 -translate-x-1/2 translate-y-3 bg-gray-900 text-white text-xs rounded-md font-ppsupply">
+        {text}
+      </span>
+    </div>
+  );
+};
+
 export default function Home() {
   const [isChatVisible, setIsChatVisible] = useState(false);
   const [initialMessage, setInitialMessage] = useState("");
@@ -98,12 +109,18 @@ export default function Home() {
 
           {/* Main Content */}
           <main className="flex-1 flex flex-col items-center justify-center p-6">
-            <div className="w-full max-w-[640px] bg-white border border-gray-200 shadow-sm overflow-hidden">
+            <div className="w-full max-w-[640px] bg-white border border-gray-200 shadow-sm">
               <div className="w-full h-12 bg-white border-b border-gray-200 flex items-center px-4">
                 <div className="flex items-center gap-2">
-                  <div className="w-3 h-3 rounded-full bg-red-500" />
-                  <div className="w-3 h-3 rounded-full bg-yellow-500" />
-                  <div className="w-3 h-3 rounded-full bg-green-500" />
+                  <Tooltip text="why would you want to close this?">
+                    <div className="w-3 h-3 rounded-full bg-red-500" />
+                  </Tooltip>
+                  <Tooltip text="s/o to the 🅱️rowserbase devs">
+                    <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                  </Tooltip>
+                  <Tooltip text="@pk_iv was here">
+                    <div className="w-3 h-3 rounded-full bg-green-500" />
+                  </Tooltip>
                 </div>
               </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
         <div className="min-h-screen bg-gray-50 flex flex-col">
           {/* Top Navigation */}
           <nav className="flex justify-between items-center px-8 py-4 bg-white border-b border-gray-200">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
               <Image
                 src="/favicon.svg"
                 alt="Open Operator"
@@ -74,7 +74,7 @@ export default function Home() {
                 width={32}
                 height={32}
               />
-              <span className="font-ppneue text-gray-900">Open Operator</span>
+              <span className="font-ppsupply text-gray-900">Open Operator</span>
             </div>
             <div className="flex items-center gap-2">
               <a

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,7 +77,11 @@ export default function Home() {
               <span className="font-ppneue text-gray-900">Open Operator</span>
             </div>
             <div className="flex items-center gap-2">
-              <a href="https://github.com/browserbase/open-operator">
+              <a
+                href="https://github.com/browserbase/open-operator"
+                target="_blank" 
+                rel="noopener noreferrer"
+              >
                 <button className="h-fit flex items-center justify-center px-4 py-2 rounded-sm bg-black gap-2 text-sm text-white border border-pillSecondary">
                   <Image
                     src="/github.svg"


### PR DESCRIPTION
- Made GitHub link open in a new tab to keep people on the page longer
- Tweaked GitHub link to more closely match GitHub style guides
![image](https://github.com/user-attachments/assets/21e77d64-d575-4083-a3ac-600df89fae6f)
- Adjusted font and spacing in header to more closely match `browserbase.com`
![image](https://github.com/user-attachments/assets/e629cb6a-e4c5-4684-ba89-b62a52f1c0a3)
- Added some fun tooltips
![image](https://github.com/user-attachments/assets/320953a3-3854-48e1-8357-05c5ddbee0c1)
