### PR TITLE
feat: add Groq support as alternative LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# OpenAI API Configuration
-OPENAI_API_KEY=your_openai_api_key_here
+# AI Model Configuration
+MODEL_PROVIDER=openai  # Options: 'openai' or 'groq'
+OPENAI_API_KEY=  # Required if MODEL_PROVIDER=openai
+GROQ_API_KEY=    # Required if MODEL_PROVIDER=groq
 
 # Browserbase Configuration
-BROWSERBASE_API_KEY=your_browserbase_api_key_here
-BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here
+BROWSERBASE_API_KEY=
+BROWSERBASE_PROJECT_ID=

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ You'll need to set up your API keys:
 
 Update `.env.local` with your API keys:
 
-- `OPENAI_API_KEY`: Your OpenAI API key
+- `MODEL_PROVIDER`: Choose between 'openai' or 'groq' for the AI model provider
+- `OPENAI_API_KEY`: Your OpenAI API key (required if using OpenAI)
+- `GROQ_API_KEY`: Your Groq API key (required if using Groq)
 - `BROWSERBASE_API_KEY`: Your Browserbase API key
 - `BROWSERBASE_PROJECT_ID`: Your Browserbase project ID
 

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -1,10 +1,27 @@
 import { NextResponse } from 'next/server';
 import { openai } from "@ai-sdk/openai";
+import { groq } from "@ai-sdk/groq";
 import { CoreMessage, generateObject, UserContent } from "ai";
 import { z } from "zod";
 import { ObserveResult, Stagehand } from "@browserbasehq/stagehand";
 
-const LLMClient = openai("gpt-4o");
+// Model configuration
+const MODEL_PROVIDER = process.env.MODEL_PROVIDER || 'openai';
+const MODEL_CONFIG = {
+  openai: {
+    provider: openai,
+    model: "gpt-4o"
+  },
+  groq: {
+    provider: groq,
+    model: "llama-3.3-70b-versatile"
+  }
+};
+
+// Initialize LLM client based on provider
+const LLMClient = MODEL_CONFIG[MODEL_PROVIDER as keyof typeof MODEL_CONFIG].provider(
+  MODEL_CONFIG[MODEL_PROVIDER as keyof typeof MODEL_CONFIG].model
+);
 
 type Step = {
   text: string;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.1.2",
+    "@ai-sdk/groq": "^1.0.0",
     "@ai-sdk/provider": "^1.0.6",
     "@browserbasehq/sdk": "^2.0.0",
     "@browserbasehq/stagehand": "^1.10.1",

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      MODEL_PROVIDER: 'openai' | 'groq';
+      OPENAI_API_KEY?: string;
+      GROQ_API_KEY?: string;
+      BROWSERBASE_API_KEY: string;
+      BROWSERBASE_PROJECT_ID: string;
+    }
+  }
+}
+
+export {}; 


### PR DESCRIPTION
## Description
This PR adds support for using Groq as an alternative LLM provider alongside OpenAI. Users can now choose between OpenAI and Groq by setting an environment variable.

## Changes
- Add Groq SDK integration
- Add environment variable support for model selection (`MODEL_PROVIDER`)
- Add type definitions for environment configuration
- Update documentation with Groq setup instructions
- Add model configuration for both providers

## Testing
- [ ] Tested with OpenAI provider
- [ ] Tested with Groq provider
- [ ] Verified environment variable switching
- [ ] Tested deployment with both providers

## Additional Notes
The implementation maintains backward compatibility while adding the flexibility to choose between LLM providers. The default provider remains OpenAI if not specified.

## Related Issues
N/A